### PR TITLE
feat: pre-draft misc. fixes

### DIFF
--- a/data/fantasyProCsv.py
+++ b/data/fantasyProCsv.py
@@ -43,7 +43,7 @@ def get_data(format):
             vsadp = text[10]
             if 'DST' not in position:
                 name, team = text[1].strip().rsplit(None, 1)
-                name = re.sub("[A-Z]\.\s.*", "", name)
+                name = re.match(r'(.*)[A-Z]\.', name).group(1)
             else:
                 name = text[1].strip()
                 name = re.match('.*\)', name).group()

--- a/src/App.css
+++ b/src/App.css
@@ -67,12 +67,12 @@ html, body {
   }
 
   .overall-rankings {
-    height: 710px;
+    height: 1100px;
     margin-bottom: 10px;
   }
 
   .draft-history {
-    height: 710px;
+    height: 1100px;
   }
 
   .table-condensed > tbody > tr > td {


### PR DESCRIPTION
This PR makes a couple minor QoL fixes that I wanted for draft day. 

The rankings and draft history boards have been given a larger height so they line up at the bottom with the DST and Kicker tables when the app is fullscreened.

The regex for parsing player names in the json has been improved to handle names with `.` in them, i.e., (J.J). This addresses https://github.com/aptmac/draftaid-react/issues/2.